### PR TITLE
Changed to use a fixed app token provided by Spritmonitor.de support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ After installation and restarting Home Assistant:
 1. Go to **Settings > Devices & Services**.
 2. Click **"Add Integration"**.
 3. Search for **"Spritmonitor"**.
-4. Enter your **Vehicle ID**, **Application ID**, and **Bearer Token** from Spritmonitor's API.
+4. Enter your **Vehicle ID** and **Bearer Token** from Spritmonitor's API.
 5. Click **"Submit"**.
 
-NOTE: Application ID = 190e3b1080a39777f369a4e9875df3d7
+NOTE: The Bearer Token can be generated on the Spritmonitor.de website (on the "change password" page, generate a new API access token).
 
 ## Available Sensors
 

--- a/custom_components/spritmonitor/__init__.py
+++ b/custom_components/spritmonitor/__init__.py
@@ -17,11 +17,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     vehicle_id = entry.data["vehicle_id"]
-    app_token = entry.data["app_token"]
     bearer_token = entry.data["bearer_token"]
 
     headers = {
-        "Application-Id": app_token,
+        "Application-Id": "095369dede84c55797c22d4854ca6efe",
         "Authorization": bearer_token
     }
 


### PR DESCRIPTION
Users don't have to set the APP token any longer as environment variable. Instead, it is hard coded into the source code as intended by Spritmonitor. 